### PR TITLE
refactor: changing cmdline view to bottom

### DIFF
--- a/lua/plugins/disabled.lua
+++ b/lua/plugins/disabled.lua
@@ -1,8 +1,1 @@
-return {
-
-  -- disable the fucking STYLED CMDLINE
-  {
-    "folke/noice.nvim",
-    enabled = false,
-  },
-}
+return {}

--- a/lua/plugins/noice.lua
+++ b/lua/plugins/noice.lua
@@ -1,0 +1,10 @@
+return {
+  {
+    "folke/noice.nvim",
+    opts = {
+      cmdline = {
+        view = "cmdline",
+      },
+    },
+  },
+}


### PR DESCRIPTION
this pr change the way cmdline render using noice.nvim

![ezgif-3-f98bb3e74f](https://github.com/rafa-thayto/lazy-vim/assets/55333929/401c5850-727a-4eba-b0c3-810e5ab9a39e)

no lazyvim quando a gente altera o opts ele faz um merge com as configs default

reference: https://github.com/folke/noice.nvim/wiki/Configuration-Recipes#classic-cmdline
